### PR TITLE
Allow to pass upsert without scripted_upsert

### DIFF
--- a/lib/corebulk.go
+++ b/lib/corebulk.go
@@ -318,11 +318,9 @@ func (b *BulkIndexer) UpdateWithWithScript(index string, _type string, id, paren
 	var data map[string]interface{} = make(map[string]interface{})
 	if scripted_upsert {
 		data["scripted_upsert"] = true
-		if upsert != nil {
-			data["upsert"] = upsert
-		} else {
-			data["upsert"] = map[string]interface{}{}
-		}
+		data["upsert"] = map[string]interface{}{}
+	} else {
+		data["upsert"] = upsert
 	}
 
 	data["script"] = script


### PR DESCRIPTION
This is setting the groundwork for changes in userlib so we dont need to hit the script.  See here: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html#upserts