### PR TITLE
Add methods for getting bulk stats

### DIFF
--- a/lib/corebulk.go
+++ b/lib/corebulk.go
@@ -188,6 +188,20 @@ func (b *BulkIndexer) Flush() {
 	b.mu.Unlock()
 }
 
+// SendBufLen gets the current length and capacity of the channel which buffers elasticsearch requests.
+func (b *BulkIndexer) SendBufLen() (length, capacity int) {
+	length = len(b.sendBuf)
+	capacity = cap(b.sendBuf)
+	return
+}
+
+// BulkChannelLen gets the current length and capacity of the channel which buffers elasticsearch operations into bulk requests
+func (b *BulkIndexer) BulkChannelLen() (length, capacity int) {
+	length = len(b.bulkChannel)
+	capacity = cap(b.bulkChannel)
+	return
+}
+
 func (b *BulkIndexer) startHttpSender() {
 
 	// this sends http requests to elasticsearch it uses maxConns to open up that


### PR DESCRIPTION
Exposes some data we'd like to get metrics on: the bulk channel length and the send buffer length.

https://app.clubhouse.io/launchdarkly/story/9868/ar-instances-occasionally-leak-a-lot-of-memory