### PR TITLE
Mark connections after using it

### DIFF
--- a/lib/baserequest.go
+++ b/lib/baserequest.go
@@ -72,6 +72,7 @@ func (c *Conn) DoCommand(method string, url string, args map[string]interface{},
 	}
 
 	httpStatusCode, body, err = req.Do(&response)
+	req.hostResponse.Mark(err)
 	if err != nil {
 		return body, err
 	}

--- a/lib/baserequest.go
+++ b/lib/baserequest.go
@@ -77,7 +77,7 @@ func (c *Conn) DoCommand(method string, url string, args map[string]interface{},
 		return body, err
 	}
 	if httpStatusCode > 304 {
-
+		req.hostResponse.Mark(ESError{time.Now(), "ES: HTTP Status Code > 304", httpStatusCode})
 		jsonErr := json.Unmarshal(body, &response)
 		if jsonErr == nil {
 			if res_err, ok := response["error"]; ok {

--- a/lib/connection.go
+++ b/lib/connection.go
@@ -162,7 +162,6 @@ func (c *Conn) NewRequest(method, path, query string) (*Request, error) {
 		uri = fmt.Sprintf("%s://%s:%s%s", c.Protocol, host, portNum, path)
 	}
 	req, err := http.NewRequest(method, uri, nil)
-	hr.Mark(err)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/connection.go
+++ b/lib/connection.go
@@ -162,6 +162,7 @@ func (c *Conn) NewRequest(method, path, query string) (*Request, error) {
 		uri = fmt.Sprintf("%s://%s:%s%s", c.Protocol, host, portNum, path)
 	}
 	req, err := http.NewRequest(method, uri, nil)
+	hr.Mark(err)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
What the title says.  Not much too it.  nil err will tell Hostpool to markSuccess, while an error will markFailed.

(FYI I threw a few of the front-end engineers to review, a lot of the backend guys our OoO)