### PR TITLE
Revert "Remove commented merge marker for go lint"

### DIFF
--- a/lib/baserequest.go
+++ b/lib/baserequest.go
@@ -58,7 +58,7 @@ func (c *Conn) DoCommand(method string, url string, args map[string]interface{},
 	// uncomment this to print out the request that hits the wire
 	//   (requires net/http/httputil)
 	//reqbuf, err := httputil.DumpRequest(req.Request, true)
-	//log.Println(fmt.Sprintf("\n req:\nURL: %s\n%s", req.URL, bytes.NewBuffer(reqbuf).String()))
+	//log.Println(fmt.Sprintf("\n========= req:\nURL: %s\n%s", req.URL, bytes.NewBuffer(reqbuf).String()))
 
 	// Copy request body for tracer
 	if c.RequestTracer != nil {


### PR DESCRIPTION
Reverts launchdarkly/elastigo#14. We'll just skip precommit hooks instead of removing the merge marker here