### PR TITLE
added in retry client into `elastigo`

### DIFF
--- a/lib/clusterreroute.go
+++ b/lib/clusterreroute.go
@@ -25,7 +25,7 @@ func (c *Conn) Reroute(dryRun bool, commands Commands) (ClusterHealthResponse, e
 	var retval ClusterHealthResponse
 
 	if len(commands.Commands) > 0 {
-		url = fmt.Sprintf("/_cluster/reroute%s&%s", dryRunOption(dryRun))
+		url = fmt.Sprintf("/_cluster/reroute&%s", dryRunOption(dryRun))
 	} else {
 		return retval, errors.New("Must pass at least one command")
 	}

--- a/lib/connection.go
+++ b/lib/connection.go
@@ -29,7 +29,7 @@ const (
 	Version         = "0.0.2"
 	DefaultProtocol = "http"
 	DefaultDomain   = "localhost"
-	DefaultPort     = "9200"
+	DefaultPort     = "9205"
 	// A decay duration of zero results in the default behaviour
 	DefaultDecayDuration = 0
 )

--- a/lib/connection.go
+++ b/lib/connection.go
@@ -14,13 +14,15 @@ package elastigo
 import (
 	"errors"
 	"fmt"
-	hostpool "github.com/bitly/go-hostpool"
 	"net/http"
 	"net/url"
 	"runtime"
 	"strings"
 	"sync"
 	"time"
+
+	hostpool "github.com/bitly/go-hostpool"
+	retry "github.com/hashicorp/go-retryablehttp"
 )
 
 const (
@@ -33,7 +35,7 @@ const (
 )
 
 var (
-	httpClient *http.Client = &http.Client{Transport: http.DefaultTransport}
+	httpClient *http.Client = retry.NewClient().HTTPClient
 )
 
 type Conn struct {

--- a/lib/corebulk_test.go
+++ b/lib/corebulk_test.go
@@ -84,8 +84,8 @@ func TestBulkIndexerBasic(t *testing.T) {
 	c.DeleteIndex(testIndex)
 
 	indexer := c.NewBulkIndexer(3)
-	indexer.Sender = func(buf *bytes.Buffer) error {
-		messageSets += 1
+	indexer.Sender = func(buf *bytes.Buffer) (BulkResponseStruct, error) {
+		messageSets++
 		totalBytesSent += buf.Len()
 		buffers.Append(buf)
 		//log.Printf("buffer:%s", string(buf.Bytes()))
@@ -195,7 +195,7 @@ func XXXTestBulkUpdate(t *testing.T) {
 	c := NewTestConn()
 	c.Port = "9200"
 	indexer := c.NewBulkIndexer(3)
-	indexer.Sender = func(buf *bytes.Buffer) error {
+	indexer.Sender = func(buf *bytes.Buffer) (BulkResponseStruct, error) {
 		messageSets += 1
 		totalBytesSent += buf.Len()
 		buffers.Append(buf)
@@ -254,7 +254,7 @@ func TestBulkSmallBatch(t *testing.T) {
 	indexer.BufferDelayMax = 100 * time.Millisecond
 	indexer.BulkMaxDocs = 2
 	messageSets = 0
-	indexer.Sender = func(buf *bytes.Buffer) error {
+	indexer.Sender = func(buf *bytes.Buffer) (BulkResponseStruct, error) {
 		messageSets += 1
 		return indexer.Send(buf)
 	}
@@ -278,11 +278,11 @@ func TestBulkDelete(t *testing.T) {
 	indexer := c.NewBulkIndexer(1)
 	sentBytes := []byte{}
 
-	indexer.Sender = func(buf *bytes.Buffer) error {
+	indexer.Sender = func(buf *bytes.Buffer) (BulkResponseStruct, error) {
 		lock.Lock()
 		sentBytes = append(sentBytes, buf.Bytes()...)
 		lock.Unlock()
-		return nil
+		return BulkResponseStruct{}, nil
 	}
 
 	indexer.Start()
@@ -346,7 +346,7 @@ func BenchmarkSend(b *testing.B) {
 	totalBytes := 0
 	sets := 0
 	indexer := c.NewBulkIndexer(1)
-	indexer.Sender = func(buf *bytes.Buffer) error {
+	indexer.Sender = func(buf *bytes.Buffer) (BulkResponseStruct, error) {
 		totalBytes += buf.Len()
 		sets += 1
 		//log.Println("got bulk")
@@ -384,7 +384,7 @@ func BenchmarkSendBytes(b *testing.B) {
 	totalBytes := 0
 	sets := 0
 	indexer := c.NewBulkIndexer(1)
-	indexer.Sender = func(buf *bytes.Buffer) error {
+	indexer.Sender = func(buf *bytes.Buffer) (BulkResponseStruct, error) {
 		totalBytes += buf.Len()
 		sets += 1
 		return indexer.Send(buf)

--- a/lib/coretest_test.go
+++ b/lib/coretest_test.go
@@ -121,13 +121,13 @@ func LoadTestData() {
 	docCt := 0
 	errCt := 0
 	indexer := c.NewBulkIndexer(1)
-	indexer.Sender = func(buf *bytes.Buffer) error {
+	indexer.Sender = func(buf *bytes.Buffer) (BulkResponseStruct, error) {
 		// log.Printf("Sent %d bytes total %d docs sent", buf.Len(), docCt)
 		req, err := c.NewRequest("POST", "/_bulk", "")
 		if err != nil {
 			errCt += 1
 			log.Fatalf("ERROR: %v", err)
-			return err
+			return BulkResponseStruct{}, err
 		}
 		req.SetBody(buf)
 		//		res, err := http.DefaultClient.Do(*(api.Request(req)))
@@ -136,12 +136,12 @@ func LoadTestData() {
 		if err != nil {
 			errCt += 1
 			log.Fatalf("ERROR: %v", err)
-			return err
+			return BulkResponseStruct{}, err
 		}
 		if httpStatusCode != 200 {
 			log.Fatalf("Not 200! %d %q\n", httpStatusCode, buf.String())
 		}
-		return nil
+		return BulkResponseStruct{}, nil
 	}
 	indexer.Start()
 	resp, err := http.Get("http://data.githubarchive.org/2012-12-10-15.json.gz")


### PR DESCRIPTION
https://app.clubhouse.io/launchdarkly/story/29678/request-timeout-in-bulk-update-to-es
[ch29678]

Updated the ES HTTP client to use the retry client