### PR TITLE
[ch54162] Fix race condition if shutting down rightafter adding to the doc channel

### DIFF
--- a/lib/corebulk.go
+++ b/lib/corebulk.go
@@ -282,7 +282,6 @@ func (b *BulkIndexer) startTimer() {
 
 func (b *BulkIndexer) startDocChannel() (doneSignal <-chan struct{}) {
 	doneChan := make(chan struct{})
-	doneSignal = doneChan
 
 	// This goroutine accepts incoming byte arrays from the IndexBulk function and
 	// writes to buffer
@@ -301,7 +300,7 @@ func (b *BulkIndexer) startDocChannel() (doneSignal <-chan struct{}) {
 		close(doneChan)
 	}()
 
-	return doneSignal
+	return doneChan
 }
 
 func (b *BulkIndexer) send(buf *bytes.Buffer) {


### PR DESCRIPTION
When shutting down, the current code has no guarantee that there aren't some documents enqueued in the buffered `bulkChannel`. In tests which enqueue a bunch of updates and immediately call a flush (which will now mean shutdown + recreate), this caused `tried to send on closed channel` panics.

Now it'll close the `bulkChannel` and wait for the bulk channel reading goroutine to get to the end before continuing with shutdown.